### PR TITLE
[fix] workflow bug

### DIFF
--- a/.github/workflows/build-and-push.yml
+++ b/.github/workflows/build-and-push.yml
@@ -7,7 +7,7 @@ on:
       - develop
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{github.repository}}
+  IMAGE_NAME: school-meal-lover/backend
 
 jobs:
   build_and_push:


### PR DESCRIPTION
image name 에서 조직의 이름에 대문자가 섞여 있어 오류가 발생합니다. 
소문자로 하드코딩하여 수정합니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Docker image name used in the build and push workflow to a fixed value for consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->